### PR TITLE
Update form submissions API URL

### DIFF
--- a/submit_data.py
+++ b/submit_data.py
@@ -122,7 +122,7 @@ def submit_xform(xform: str) -> Tuple[bool, str]:
     failure_message) on failure.
     """
     url = join_url(COMMCARE_URL,
-                   f'/a/{os.environ["CCHQ_PROJECT_SPACE"]}/receiver/')
+                   f'/a/{os.environ["CCHQ_PROJECT_SPACE"]}/receiver/api/')
     auth = (os.environ['CCHQ_USERNAME'], os.environ['CCHQ_PASSWORD'])
     headers = {'Content-Type': 'text/html; charset=UTF-8'}
     response = requests.post(url, xform.encode('utf-8'),


### PR DESCRIPTION
We just added a new api-specific endpoint for form submissions:
https://github.com/dimagi/commcare-hq/pull/30784
https://confluence.dimagi.com/display/commcarepublic/Submission+API